### PR TITLE
Fix link to repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["supabase", "supabase-auth", "authentication", "auth"]
 categories = ["authentication", "database"]
 homepage = "https://supabase.com"
-repository = "https://github.com/proziam/supabase-auth"
+repository = "https://github.com/proziam/supabase-auth-rs"
 
 [dependencies]
 reqwest = "0.12.7"


### PR DESCRIPTION
Current link is wrong/outdated, and gives error 404