### PR TITLE
Move tokio dependency to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ reqwest = "0.12.7"
 serde = { version = "1.0.208", features = ["derive"] }
 serde_json = "1.0.127"
 thiserror = "1.0.63"
-tokio = { version = "1.39.3", features = ["full"] }
 
 [dev-dependencies]
 uuid = { version = "1.10.0", features = ["v7"] }
+tokio = { version = "1.39.3", features = ["full"] }


### PR DESCRIPTION
It's not used in library directly, only in tests, and the dependency does not compile for wasm.