### PR TITLE
Reduced allocations by using &str instead of String

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -72,15 +72,8 @@ impl AuthClient {
     ///
     /// assert!(session.user.email == demo_email)
     /// ```
-    pub async fn login_with_email<S: Into<String>>(
-        &self,
-        email: S,
-        password: S,
-    ) -> Result<Session, Error> {
-        let payload = SignInWithEmailAndPasswordPayload {
-            email: email.into(),
-            password: password.into(),
-        };
+    pub async fn login_with_email(&self, email: &str, password: &str) -> Result<Session, Error> {
+        let payload = SignInWithEmailAndPasswordPayload { email, password };
 
         let mut headers = header::HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
@@ -119,15 +112,8 @@ impl AuthClient {
     ///
     /// assert!(session.user.phone == demo_phone)
     /// ```
-    pub async fn login_with_phone<S: Into<String>>(
-        &self,
-        phone: S,
-        password: S,
-    ) -> Result<Session, Error> {
-        let payload = SignInWithPhoneAndPasswordPayload {
-            phone: phone.into(),
-            password: password.into(),
-        };
+    pub async fn login_with_phone(&self, phone: &str, password: &str) -> Result<Session, Error> {
+        let payload = SignInWithPhoneAndPasswordPayload { phone, password };
 
         let mut headers = header::HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
@@ -167,15 +153,15 @@ impl AuthClient {
     ///
     /// assert!(session.user.email == demo_email)
     ///```
-    pub async fn sign_up_with_email_and_password<S: Into<String>>(
+    pub async fn sign_up_with_email_and_password(
         &self,
-        email: S,
-        password: S,
+        email: &str,
+        password: &str,
         options: Option<SignUpWithPasswordOptions>,
     ) -> Result<Session, Error> {
         let payload = SignUpWithEmailAndPasswordPayload {
-            email: email.into(),
-            password: password.into(),
+            email,
+            password,
             options,
         };
 
@@ -214,15 +200,15 @@ impl AuthClient {
     ///
     /// assert!(session.user.phone == demo_phone)
     ///```
-    pub async fn sign_up_with_phone_and_password<S: Into<String>>(
+    pub async fn sign_up_with_phone_and_password(
         &self,
-        phone: S,
-        password: S,
+        phone: &str,
+        password: &str,
         options: Option<SignUpWithPasswordOptions>,
     ) -> Result<Session, Error> {
         let payload = SignUpWithPhoneAndPasswordPayload {
-            phone: phone.into(),
-            password: password.into(),
+            phone,
+            password,
             options,
         };
 
@@ -259,13 +245,8 @@ impl AuthClient {
     ///    .await
     ///    .unwrap();
     ///```
-    pub async fn send_login_email_with_magic_link<S: Into<String>>(
-        &self,
-        email: S,
-    ) -> Result<(), Error> {
-        let payload = RequestMagicLinkPayload {
-            email: email.into(),
-        };
+    pub async fn send_login_email_with_magic_link(&self, email: &str) -> Result<(), Error> {
+        let payload = RequestMagicLinkPayload { email };
 
         let mut headers = header::HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
@@ -302,10 +283,8 @@ impl AuthClient {
     /// ```
     /// let response = auth_client.send_sms_with_otp(demo_phone).await;
     /// ```
-    pub async fn send_sms_with_otp<S: Into<String>>(&self, phone: S) -> Result<OTPResponse, Error> {
-        let payload = SendSMSOtpPayload {
-            phone: phone.into(),
-        };
+    pub async fn send_sms_with_otp(&self, phone: &str) -> Result<OTPResponse, Error> {
+        let payload = SendSMSOtpPayload { phone };
 
         let mut headers = header::HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
@@ -342,15 +321,12 @@ impl AuthClient {
     /// ```
     /// let send = auth_client.send_sms_with_otp(demo_phone).await.unwrap();
     /// ```
-    pub async fn send_email_with_otp<S: Into<String>>(
+    pub async fn send_email_with_otp(
         &self,
-        email: S,
+        email: &str,
         options: Option<SignInEmailOtpParams>,
     ) -> Result<OTPResponse, Error> {
-        let payload = SignInWithEmailOtpPayload {
-            email: email.into(),
-            options,
-        };
+        let payload = SignInWithEmailOtpPayload { email, options };
 
         let mut headers = header::HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
@@ -447,12 +423,12 @@ impl AuthClient {
     ///
     /// assert!(user.email == demo_email)
     /// ```
-    pub async fn get_user<S: Into<String>>(&self, bearer_token: S) -> Result<User, Error> {
+    pub async fn get_user(&self, bearer_token: &str) -> Result<User, Error> {
         let mut headers = header::HeaderMap::new();
         headers.insert("apikey", HeaderValue::from_str(&self.api_key)?);
         headers.insert(
             AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &bearer_token.into()))?,
+            HeaderValue::from_str(&format!("Bearer {}", bearer_token))?,
         );
 
         let response = self
@@ -487,17 +463,17 @@ impl AuthClient {
     ///     .await
     ///     .unwrap();
     /// ```
-    pub async fn update_user<S: Into<String>>(
+    pub async fn update_user(
         &self,
         updated_user: UpdateUserPayload,
-        bearer_token: S,
+        bearer_token: &str,
     ) -> Result<User, Error> {
         let mut headers = header::HeaderMap::new();
         headers.insert("apikey", HeaderValue::from_str(&self.api_key)?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
         headers.insert(
             AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &bearer_token.into()))?,
+            HeaderValue::from_str(&format!("Bearer {}", bearer_token))?,
         );
 
         let body = serde_json::to_string::<UpdateUserPayload>(&updated_user)?;
@@ -579,18 +555,18 @@ impl AuthClient {
     ///     .await
     ///     .unwrap();
     ///```
-    pub async fn invite_user_by_email<S: Into<String>>(
+    pub async fn invite_user_by_email(
         &self,
-        email: S,
+        email: &str,
         data: Option<Value>,
-        bearer_token: S,
+        bearer_token: &str,
     ) -> Result<User, Error> {
         let mut headers = HeaderMap::new();
         headers.insert("apikey", HeaderValue::from_str(&self.api_key)?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
         headers.insert(
             AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &bearer_token.into()))?,
+            HeaderValue::from_str(&format!("Bearer {}", bearer_token))?,
         );
 
         let invite_payload = InviteParams {
@@ -735,17 +711,12 @@ impl AuthClient {
     ///     .await
     ///     .unwrap();
     /// ```
-    pub async fn exchange_token_for_session<S: Into<String>>(
-        &self,
-        refresh_token: S,
-    ) -> Result<Session, Error> {
+    pub async fn exchange_token_for_session(&self, refresh_token: &str) -> Result<Session, Error> {
         let mut headers = HeaderMap::new();
         headers.insert("apikey", HeaderValue::from_str(&self.api_key)?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
 
-        let body = serde_json::to_string(&RefreshSessionPayload {
-            refresh_token: refresh_token.into(),
-        })?;
+        let body = serde_json::to_string(&RefreshSessionPayload { refresh_token })?;
 
         let response = self
             .client
@@ -769,7 +740,7 @@ impl AuthClient {
         Ok(session)
     }
 
-    pub async fn refresh_session(&self, refresh_token: String) -> Result<Session, Error> {
+    pub async fn refresh_session(&self, refresh_token: &str) -> Result<Session, Error> {
         self.exchange_token_for_session(refresh_token).await
     }
 
@@ -779,7 +750,7 @@ impl AuthClient {
     /// ```
     /// let response = auth_client.reset_password_for_email(demo_email).await.unwrap();
     /// ```
-    pub async fn reset_password_for_email<S: Into<String>>(&self, email: S) -> Result<(), Error> {
+    pub async fn reset_password_for_email(&self, email: &str) -> Result<(), Error> {
         let mut headers = HeaderMap::new();
         headers.insert("apikey", HeaderValue::from_str(&self.api_key)?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
@@ -854,17 +825,17 @@ impl AuthClient {
     /// ```
     /// auth_client.logout(Some(LogoutScope::Global), session.access_token).await.unwrap();
     /// ```
-    pub async fn logout<S: Into<String>>(
+    pub async fn logout(
         &self,
         scope: Option<LogoutScope>,
-        bearer_token: S,
+        bearer_token: &str,
     ) -> Result<(), Error> {
         let mut headers = HeaderMap::new();
         headers.insert("apikey", HeaderValue::from_str(&self.api_key)?);
         headers.insert(CONTENT_TYPE, HeaderValue::from_str("application/json")?);
         headers.insert(
             AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {}", &bearer_token.into()))?,
+            HeaderValue::from_str(&format!("Bearer {}", bearer_token))?,
         );
 
         let body = serde_json::to_string(&scope)?;
@@ -931,17 +902,17 @@ impl AuthClient {
     }
 
     /// Get the project URL from an AuthClient
-    pub fn project_url(&self) -> &String {
+    pub fn project_url(&self) -> &str {
         &self.project_url
     }
 
     /// Get the API Key from an AuthClient
-    pub fn api_key(&self) -> &String {
+    pub fn api_key(&self) -> &str {
         &self.api_key
     }
 
     /// Get the JWT Secret from an AuthClient
-    pub fn jwt_secret(&self) -> &String {
+    pub fn jwt_secret(&self) -> &str {
         &self.jwt_secret
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -150,28 +150,28 @@ pub enum LoginOptions {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SignInWithEmailAndPasswordPayload {
-    pub(crate) email: String,
-    pub(crate) password: String,
+pub struct SignInWithEmailAndPasswordPayload<'a> {
+    pub(crate) email: &'a str,
+    pub(crate) password: &'a str,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SignInWithPhoneAndPasswordPayload {
-    pub(crate) phone: String,
-    pub(crate) password: String,
+pub struct SignInWithPhoneAndPasswordPayload<'a> {
+    pub(crate) phone: &'a str,
+    pub(crate) password: &'a str,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SignUpWithEmailAndPasswordPayload {
-    pub(crate) email: String,
-    pub(crate) password: String,
+pub struct SignUpWithEmailAndPasswordPayload<'a> {
+    pub(crate) email: &'a str,
+    pub(crate) password: &'a str,
     pub(crate) options: Option<SignUpWithPasswordOptions>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SignUpWithPhoneAndPasswordPayload {
-    pub(crate) phone: String,
-    pub(crate) password: String,
+pub struct SignUpWithPhoneAndPasswordPayload<'a> {
+    pub(crate) phone: &'a str,
+    pub(crate) password: &'a str,
     pub(crate) options: Option<SignUpWithPasswordOptions>,
 }
 
@@ -188,8 +188,8 @@ pub struct SignUpWithPasswordOptions {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct RequestMagicLinkPayload {
-    pub(crate) email: String,
+pub struct RequestMagicLinkPayload<'a> {
+    pub(crate) email: &'a str,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -200,8 +200,8 @@ pub struct UpdateUserPayload {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct SendSMSOtpPayload {
-    pub phone: String,
+pub struct SendSMSOtpPayload<'a> {
+    pub phone: &'a str,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -278,8 +278,8 @@ pub enum SignInWithOtp {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
-pub struct SignInWithEmailOtpPayload {
-    pub email: String,
+pub struct SignInWithEmailOtpPayload<'a> {
+    pub email: &'a str,
     pub options: Option<SignInEmailOtpParams>,
 }
 
@@ -316,8 +316,8 @@ pub struct SignInMobileOtpParams {
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct RefreshSessionPayload {
-    pub refresh_token: String,
+pub struct RefreshSessionPayload<'a> {
+    pub refresh_token: &'a str,
 }
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/tests/client_tests.rs
+++ b/tests/client_tests.rs
@@ -80,7 +80,7 @@ async fn test_mobile_flow() {
     };
 
     let session = auth_client
-        .sign_up_with_phone_and_password(demo_phone.clone(), demo_password.clone(), Some(options))
+        .sign_up_with_phone_and_password(&demo_phone, &demo_password, Some(options))
         .await;
 
     if session.is_err() {
@@ -99,7 +99,7 @@ async fn test_mobile_flow() {
 
     assert!(new_session.is_ok() && new_session.unwrap().user.phone == demo_phone);
 
-    let response = auth_client.send_sms_with_otp(demo_phone).await;
+    let response = auth_client.send_sms_with_otp(&demo_phone).await;
 
     if response.is_err() {
         eprintln!("{:?}", response.as_ref().unwrap_err())
@@ -115,7 +115,7 @@ async fn send_login_email_with_magic_link() {
     let demo_email = env::var("DEMO_EMAIL").unwrap();
 
     let response = auth_client
-        .send_login_email_with_magic_link(demo_email)
+        .send_login_email_with_magic_link(&demo_email)
         .await;
 
     if response.is_err() {
@@ -135,7 +135,7 @@ async fn send_email_with_otp() {
 
     let demo_email = env::var("DEMO_EMAIL").unwrap();
 
-    let response = auth_client.send_email_with_otp(demo_email, None).await;
+    let response = auth_client.send_email_with_otp(&demo_email, None).await;
 
     if response.is_err() {
         eprintln!("{:?}", response.as_ref().unwrap_err())
@@ -224,7 +224,7 @@ async fn get_user_test() {
     }
 
     let user = auth_client
-        .get_user(session.unwrap().access_token)
+        .get_user(&session.unwrap().access_token)
         .await
         .unwrap();
 
@@ -253,7 +253,7 @@ async fn update_user_test() {
     };
 
     let first_response = auth_client
-        .update_user(updated_user, session.access_token)
+        .update_user(updated_user, &session.access_token)
         .await;
 
     if first_response.is_err() {
@@ -279,7 +279,7 @@ async fn update_user_test() {
     };
 
     let second_response = auth_client
-        .update_user(original_user, new_session.unwrap().access_token)
+        .update_user(original_user, &new_session.unwrap().access_token)
         .await;
 
     assert!(second_response.is_ok())
@@ -300,7 +300,7 @@ async fn exchange_token_for_session() {
     assert!(original_session.user.email == demo_email);
 
     let new_session = auth_client
-        .refresh_session(original_session.refresh_token)
+        .refresh_session(&original_session.refresh_token)
         .await
         .unwrap();
 
@@ -313,7 +313,7 @@ async fn reset_password_for_email_test() {
 
     let demo_email = env::var("DEMO_EMAIL").unwrap();
 
-    let response = auth_client.reset_password_for_email(demo_email).await;
+    let response = auth_client.reset_password_for_email(&demo_email).await;
 
     // Wait to prevent running into Supabase rate limits when running cargo test
     let one_minute = time::Duration::from_secs(60);
@@ -332,7 +332,7 @@ async fn resend_email_test() {
     let demo_password = "ciJUAojfZZYKfCxkiUWH";
 
     let session = auth_client
-        .sign_up_with_email_and_password(demo_email.clone(), demo_password.to_string(), None)
+        .sign_up_with_email_and_password(&demo_email, demo_password, None)
         .await;
 
     if session.is_err() {
@@ -366,12 +366,12 @@ async fn logout_test() {
     let demo_password = env::var("DEMO_PASSWORD").unwrap();
 
     let session = auth_client
-        .login_with_email(demo_email, demo_password.to_string())
+        .login_with_email(&demo_email, &demo_password)
         .await
         .unwrap();
 
     let logout = auth_client
-        .logout(Some(LogoutScope::Global), session.access_token)
+        .logout(Some(LogoutScope::Global), &session.access_token)
         .await;
 
     if logout.is_err() {


### PR DESCRIPTION
This PR reduces potential allocations by using string slices (`&str`) instead of owned strings (`String`) in many API methods. Note that this is a breaking change and might need a major version bump.