### PR TITLE
Anonymous Sign-In

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -176,6 +176,11 @@ pub(crate) struct SignUpWithPhoneAndPasswordPayload<'a> {
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SignInAnonymouslyPayload {
+    pub(crate) options: Option<SignUpWithPasswordOptions>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SignUpWithPasswordOptions {
     /// The redirect url embedded in the email link
     pub email_redirect_to: Option<String>,


### PR DESCRIPTION
The `@supabase/auth-js` client has a `signInAnonymously()` method that lets someone sign into the Supabase API using an anonymous user. It takes the same options argument as the signup methods, and works relatively the same, the only difference is that it doesn't pass any identifying credentials. The implementation here was referenced from the official JS client, with source available at <https://github.com/supabase/auth-js/blob/436fd9f967ad6d515b8eca179d06032619a1b071/src/GoTrueClient.ts#L367-L403>.